### PR TITLE
Fix for invoices with multiple qr coders

### DIFF
--- a/source/al-version/src/codeunit/PTEDCSwissQRMgt.Codeunit.al
+++ b/source/al-version/src/codeunit/PTEDCSwissQRMgt.Codeunit.al
@@ -219,7 +219,6 @@ Word: Text[1024]): Boolean
                 //ValidQRBillCodeFound += 1;
                 if SwissQRBillDecode.DecodeQRCodeText(CurrentSwissQRBillBuffer, QRBillContent) then begin
                     if IsNewQRBillCode(TempSwissQRBillBuffer, CurrentSwissQRBillBuffer) then begin
-                        // if ValidQRBillCodeFound > 0 then
                         ValidQRBillCodeFound += 1;
 
                         TempSwissQRBillBuffer.Init();

--- a/source/al-version/src/codeunit/PTEDCSwissQRMgt.Codeunit.al
+++ b/source/al-version/src/codeunit/PTEDCSwissQRMgt.Codeunit.al
@@ -219,8 +219,8 @@ Word: Text[1024]): Boolean
                 //ValidQRBillCodeFound += 1;
                 if SwissQRBillDecode.DecodeQRCodeText(CurrentSwissQRBillBuffer, QRBillContent) then begin
                     if IsNewQRBillCode(TempSwissQRBillBuffer, CurrentSwissQRBillBuffer) then begin
-                        if ValidQRBillCodeFound > 0 then
-                            ValidQRBillCodeFound += 1;
+                        // if ValidQRBillCodeFound > 0 then
+                        ValidQRBillCodeFound += 1;
 
                         TempSwissQRBillBuffer.Init();
                         TempSwissQRBillBuffer."Entry No." := ValidQRBillCodeFound;


### PR DESCRIPTION
If 2 QR Codes are present on a bill, an error occurred -
Der Datensatz existiert bereits in der Tabelle QR-Rechnungspuffer. Identifizierende Felder und Werte: Laufnr.='0'.

The Callstack is missleading probably because of buffered inserts. But with this fix, the error disappeared.

"PTE DC SwissQR Mgt."(CodeUnit 61110).FindQRPaymentCodeInDocument line 45 - PTE DC Swiss QR-Bill Management by github.com/document-capture
"PTE DC SwissQR Mgt."(CodeUnit 61110).SetCurrencyFromQRCode line 5 - PTE DC Swiss QR-Bill Management by github.com/document-capture
"PTE DC SwissQR Mgt."(CodeUnit 61110).CaptureEngineOnBeforeCaptureField2 line 8 - PTE DC Swiss QR-Bill Management by github.com/document-capture
"CDC Capture Engine"(CodeUnit 6085575).OnBeforeCaptureField2(Event) line 2 - Continia Document Capture by Continia Software
"CDC Capture Engine"(CodeUnit 6085575).CaptureField2 line 8 - Continia Document Capture by Continia Software
"CDC Capture Engine"(CodeUnit 6085575).CaptureField line 4 - Continia Document Capture by Continia Software
"CDC Capture Engine"(CodeUnit 6085575).CaptureDocument line 104 - Continia Document Capture by Continia Software
